### PR TITLE
Remove stderr subprocess

### DIFF
--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -121,7 +121,6 @@ def call_subprocess(
             # Convert HiddenText objects to the underlying str.
             reveal_command_args(cmd),
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
             cwd=cwd
         )
         if proc.stdin:


### PR DESCRIPTION
Rather than pipe the error output, we will just remove it from the subprocess capture entirely. This is at the recommendation of @sbidoul. This may have been the root cause in the introduction of hanging git installs in 20.2, along with other errors.